### PR TITLE
Linting pr 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+      #    run linting
+      - name: Run Lint
+        run: npm run lint
 
       - name: Run tests
         run: npm run test

--- a/.github/workflows/develop-check.yml
+++ b/.github/workflows/develop-check.yml
@@ -36,6 +36,9 @@ jobs:
 
     - name: Install dependencies
       run: npm ci
+#    run linting
+    - name: Run Lint
+      run: npm run lint
 
 
     - name: Run tests

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "migration:generate": "npm run typeorm -- migration:generate -d typeorm.config.ts",
     "migration:run": "npm run typeorm -- migration:run -d typeorm.config.ts",
     "migration:revert": "npm run typeorm -- migration:revert -d typeorm.config.ts",
-    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",
+    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",

--- a/src/app.module.spec.ts
+++ b/src/app.module.spec.ts
@@ -1,122 +1,107 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ConfigModule, ConfigService } from '@nestjs/config';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
 import { DataSource } from 'typeorm';
-import { randomUUID } from 'crypto';
+import { AppModule } from './app.module';
+import { AuthModule } from './auth/auth.module';
+import { UserModule } from './user/user.module';
+import { PhotoModule } from './photo/photo.module';
+import { FeedModule } from './feed/feed.module';
+import { InteractionModule } from './interaction/interaction.module';
+import { SearchModule } from './search/search.module';
+import { NotificationModule } from './notification/notification.module';
 
-global.crypto = {
-  randomUUID,
-  subtle: {} as SubtleCrypto,
-  getRandomValues: () => new Uint8Array(10),
-} as Crypto;
+// Mock feature modules
+jest.mock('./auth/auth.module', () => ({
+  AuthModule: jest.fn(),
+}));
+jest.mock('./user/user.module', () => ({
+  UserModule: jest.fn(),
+}));
+jest.mock('./photo/photo.module', () => ({
+  PhotoModule: jest.fn(),
+}));
+jest.mock('./feed/feed.module', () => ({
+  FeedModule: jest.fn(),
+}));
+jest.mock('./interaction/interaction.module', () => ({
+  InteractionModule: jest.fn(),
+}));
+jest.mock('./search/search.module', () => ({
+  SearchModule: jest.fn(),
+}));
+jest.mock('./notification/notification.module', () => ({
+  NotificationModule: jest.fn(),
+}));
 
-jest.mock('typeorm', () => {
-  const actual = jest.requireActual('typeorm');
-  return {
-    ...actual,
-    DataSource: jest.fn().mockImplementation(() => ({
-      initialize: jest.fn().mockResolvedValue({}),
-      destroy: jest.fn().mockResolvedValue({}),
-      createQueryRunner: jest.fn().mockReturnValue({
-        connect: jest.fn(),
-        startTransaction: jest.fn(),
-        commitTransaction: jest.fn(),
-        rollbackTransaction: jest.fn(),
-        release: jest.fn(),
-      }),
-    })),
-  };
-});
+const mockConfigService = {
+  get: jest.fn((key: string): string => {
+    const config: Record<string, string> = {
+      DB_HOST: 'localhost',
+      DB_PORT: '5432',
+      DB_USERNAME: 'postgres',
+      DB_PASSWORD: 'postgres',
+      DB_NAME: 'photo_inc',
+      NODE_ENV: 'test',
+    };
+    return config[key] ?? '';
+  }),
+};
+
+const mockDataSource = {
+  initialize: jest
+    .fn()
+    .mockImplementation((): Promise<void> => Promise.resolve()),
+  destroy: jest.fn().mockImplementation((): Promise<void> => Promise.resolve()),
+  createQueryRunner: jest.fn().mockImplementation(() => ({
+    connect: jest.fn(),
+    startTransaction: jest.fn(),
+    commitTransaction: jest.fn(),
+    rollbackTransaction: jest.fn(),
+    release: jest.fn(),
+  })),
+};
 
 describe('AppModule', () => {
-  let module: TestingModule;
+  let testModule: TestingModule;
 
   beforeEach(async () => {
-    const moduleRef = Test.createTestingModule({
-      imports: [
-        ConfigModule.forRoot({
-          isGlobal: true,
-          load: [
-            () => ({
-              JWT_SECRET: 'test-secret',
-              AWS_ACCESS_KEY_ID: 'test-key',
-              AWS_SECRET_ACCESS_KEY: 'test-secret',
-              AWS_REGION: 'us-east-1',
-              AWS_S3_BUCKET: 'test-bucket',
-              DATABASE_HOST: 'localhost',
-              DATABASE_PORT: 5432,
-              DATABASE_USERNAME: 'test',
-              DATABASE_PASSWORD: 'test',
-              DATABASE_NAME: 'test',
-            }),
-          ],
-        }),
-        TypeOrmModule.forRootAsync({
-          imports: [ConfigModule],
-          inject: [ConfigService],
-          useFactory: () => ({
-            type: 'postgres',
-            host: 'localhost',
-            port: 5432,
-            username: 'test',
-            password: 'test',
-            database: 'test',
-            autoLoadEntities: true,
-            synchronize: false,
-          }),
-        }),
-      ],
-      providers: [
-        {
-          provide: ConfigService,
-          useValue: {
-            get: jest.fn((key: string) => {
-              const config = {
-                JWT_SECRET: 'test-secret',
-                AWS_ACCESS_KEY_ID: 'test-key',
-                AWS_SECRET_ACCESS_KEY: 'test-secret',
-                AWS_REGION: 'us-east-1',
-                AWS_S3_BUCKET: 'test-bucket',
-                DATABASE_HOST: 'localhost',
-                DATABASE_PORT: 5432,
-                DATABASE_USERNAME: 'test',
-                DATABASE_PASSWORD: 'test',
-                DATABASE_NAME: 'test',
-              };
-              return config[key];
-            }),
-          },
-        },
-        {
-          provide: DataSource,
-          useValue: {
-            createQueryRunner: () => ({
-              connect: jest.fn(),
-              startTransaction: jest.fn(),
-              commitTransaction: jest.fn(),
-              rollbackTransaction: jest.fn(),
-              release: jest.fn(),
-            }),
-          },
-        },
-      ],
-    }).compile();
+    const module = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(ConfigService)
+      .useValue(mockConfigService)
+      .overrideProvider(DataSource)
+      .useValue(mockDataSource)
+      .compile();
 
-    module = await moduleRef;
+    testModule = module;
   });
 
   it('should be defined', () => {
-    expect(module).toBeDefined();
+    expect(testModule).toBeDefined();
   });
 
-  it('should have ConfigModule configured', () => {
-    const configModule = module.get(ConfigModule);
-    expect(configModule).toBeDefined();
+  it('should have ConfigService configured', () => {
+    const configService = testModule.get(ConfigService);
+    expect(configService).toBeDefined();
+    expect(configService.get('DB_HOST')).toBe('localhost');
+    expect(configService.get('DB_PORT')).toBe('5432');
   });
 
-  it('should have TypeOrmModule configured', () => {
-    const configService = module.get(ConfigService);
-    expect(configService.get('DATABASE_HOST')).toBe('localhost');
-    expect(configService.get('DATABASE_PORT')).toBe(5432);
+  it('should have DataSource configured', () => {
+    const dataSource = testModule.get(DataSource);
+    expect(dataSource).toBeDefined();
+    expect(typeof dataSource.initialize).toBe('function');
+    expect(typeof dataSource.createQueryRunner).toBe('function');
+  });
+
+  it('should have all feature modules imported', () => {
+    expect(AuthModule).toBeCalled();
+    expect(UserModule).toBeCalled();
+    expect(PhotoModule).toBeCalled();
+    expect(FeedModule).toBeCalled();
+    expect(InteractionModule).toBeCalled();
+    expect(SearchModule).toBeCalled();
+    expect(NotificationModule).toBeCalled();
   });
 });

--- a/src/auth/strategies/jwt.strategy.spec.ts
+++ b/src/auth/strategies/jwt.strategy.spec.ts
@@ -155,11 +155,10 @@ describe('JwtStrategy', () => {
 
       // Create a new instance to verify constructor behavior
       const getSpy = jest.spyOn(mockConfigService, 'get');
-      const strategy = new JwtStrategy(
+      new JwtStrategy(
         mockConfigService as unknown as ConfigService,
         mockUserRepository,
       );
-
       expect(getSpy).toHaveBeenCalledWith('JWT_SECRET');
       expect(getSpy).toHaveReturnedWith('test-jwt-secret');
       getSpy.mockRestore();

--- a/src/interaction/services/comment.service.spec.ts
+++ b/src/interaction/services/comment.service.spec.ts
@@ -4,91 +4,109 @@ import { NotFoundException } from '@nestjs/common';
 import { CommentService } from './comment.service';
 import { Comment } from '../../domain/entities/comment.entity';
 import { Photo } from '../../domain/entities/photo.entity';
-import { Repository, ObjectLiteral, EntityMetadata, EntityTarget } from 'typeorm';
+import {
+  Repository,
+  ObjectLiteral,
+  EntityMetadata,
+  EntityTarget,
+} from 'typeorm';
 import { CreateCommentDto } from '../dtos/create-comment.dto';
 import '@jest/globals';
 
-const createEntityMetadata = (entity: any): EntityMetadata => ({
-  "@instanceof": Symbol.for("EntityMetadata"),
-  connection: {} as any,
-  subscribers: [],
-  target: entity,
-  tableMetadataArgs: {} as any,
-  table: {} as any,
-  columns: [],
-  relations: [],
-  relationIds: [],
-  relationCounts: [],
-  indices: [],
-  uniques: [],
-  checks: [],
-  exclusions: [],
-  embeddeds: [],
-  foreignKeys: [],
-  propertiesMap: {},
-  closureJunctionTable: {} as any,
-  name: entity.name.toLowerCase(),
-  tableName: entity.name.toLowerCase(),
-  tablePath: entity.name.toLowerCase(),
-  schemaPath: "public",
-  orderBy: {},
-  discriminatorValue: entity.name.toLowerCase(),
-  childEntityMetadatas: [],
-  ownColumns: [],
-  ownRelations: [],
-  ownIndices: [],
-  ownUniques: [],
-  ownChecks: [],
-  ownExclusions: [],
-  isClosure: false,
-  isJunction: false,
-  isAlwaysUsingConstructor: true,
-  isJunctionEntityMetadata: false,
-  isClosureJunctionEntityMetadata: false,
-  tableType: "regular",
-  expression: undefined,
-  dependsOn: {},
-  relationWithParentMetadata: undefined,
-  relationMetadatas: [],
-  inheritanceTree: [],
-  inheritancePattern: undefined,
-  treeType: undefined,
-  treeOptions: undefined,
-  targetName: entity.name,
-  givenTableName: entity.name.toLowerCase(),
-  fileType: "entity",
-  engine: undefined,
-  database: undefined,
-  schema: undefined,
-  synchronize: true,
-  withoutRowid: false,
-  createDateColumn: undefined,
-  updateDateColumn: undefined,
-  deleteDateColumn: undefined,
-  versionColumn: undefined,
-  discriminatorColumn: undefined,
-  treeLevelColumn: undefined,
-  nestedSetLeftColumn: undefined,
-  nestedSetRightColumn: undefined,
-  materializedPathColumn: undefined,
-  objectIdColumn: undefined,
-  parentClosureEntityMetadata: undefined,
-  parentEntityMetadata: undefined,
-  tableNameWithoutPrefix: entity.name.toLowerCase(),
-} as unknown as EntityMetadata);
+const createEntityMetadata = (
+  entity: new (...args: unknown[]) => Comment | Photo,
+): EntityMetadata =>
+  ({
+    '@instanceof': Symbol.for('EntityMetadata'),
+    connection: {} as Repository<Comment | Photo>['manager'],
+    subscribers: [],
+    target: entity,
+    tableMetadataArgs: {} as EntityMetadata['tableMetadataArgs'],
+    table: undefined,
+    columns: [],
+    relations: [],
+    relationIds: [],
+    relationCounts: [],
+    indices: [],
+    uniques: [],
+    checks: [],
+    exclusions: [],
+    embeddeds: [],
+    foreignKeys: [],
+    propertiesMap: {},
+    closureJunctionTable: {} as EntityMetadata['closureJunctionTable'],
+    name: entity.name.toLowerCase(),
+    tableName: entity.name.toLowerCase(),
+    tablePath: entity.name.toLowerCase(),
+    schemaPath: 'public',
+    orderBy: {},
+    discriminatorValue: entity.name.toLowerCase(),
+    childEntityMetadatas: [],
+    ownColumns: [],
+    ownRelations: [],
+    ownIndices: [],
+    ownUniques: [],
+    ownChecks: [],
+    ownExclusions: [],
+    isClosure: false,
+    isJunction: false,
+    isAlwaysUsingConstructor: true,
+    isJunctionEntityMetadata: false,
+    isClosureJunctionEntityMetadata: false,
+    tableType: 'regular',
+    expression: undefined,
+    dependsOn: {},
+    relationWithParentMetadata: undefined,
+    relationMetadatas: [],
+    inheritanceTree: [],
+    inheritancePattern: undefined,
+    treeType: undefined,
+    treeOptions: undefined,
+    targetName: entity.name,
+    givenTableName: entity.name.toLowerCase(),
+    fileType: 'entity',
+    engine: undefined,
+    database: undefined,
+    schema: undefined,
+    synchronize: true,
+    withoutRowid: false,
+    createDateColumn: undefined,
+    updateDateColumn: undefined,
+    deleteDateColumn: undefined,
+    versionColumn: undefined,
+    discriminatorColumn: undefined,
+    treeLevelColumn: undefined,
+    nestedSetLeftColumn: undefined,
+    nestedSetRightColumn: undefined,
+    materializedPathColumn: undefined,
+    objectIdColumn: undefined,
+    parentClosureEntityMetadata: undefined,
+    parentEntityMetadata: undefined,
+    tableNameWithoutPrefix: entity.name.toLowerCase(),
+  }) as unknown as EntityMetadata;
 
-type MockType<T> = {
-  [P in keyof T]: P extends 'metadata' | 'manager' | 'target' ? T[P] : jest.Mock;
-};
+// Type for repository methods
 
 type MockRepository<T extends ObjectLiteral> = {
   [P in keyof Repository<T>]: P extends 'metadata'
     ? EntityMetadata
     : P extends 'manager'
-    ? Repository<T>['manager']
-    : P extends 'target'
-    ? EntityTarget<T>
-    : jest.Mock;
+      ? Repository<T>['manager']
+      : P extends 'target'
+        ? EntityTarget<T>
+        : jest.Mock;
+} & {
+  softRemove: jest.Mock;
+  restore: jest.Mock;
+  exists: jest.Mock;
+  existsBy: jest.Mock;
+  sum: jest.Mock;
+  average: jest.Mock;
+  minimum: jest.Mock;
+  maximum: jest.Mock;
+  findOneOrFail: jest.Mock;
+  findOneByOrFail: jest.Mock;
+  queryRunner?: jest.Mock;
 };
 
 describe('CommentService', () => {
@@ -161,7 +179,7 @@ describe('CommentService', () => {
       decrement: jest.fn(),
       exist: jest.fn(),
       metadata: createEntityMetadata(Comment),
-      manager: {} as any,
+      manager: {} as Repository<Comment>['manager'],
       hasId: jest.fn(),
       getId: jest.fn(),
       target: jest.fn().mockReturnValue(Comment),
@@ -185,7 +203,7 @@ describe('CommentService', () => {
       maximum: jest.fn(),
       findOneOrFail: jest.fn(),
       findOneByOrFail: jest.fn(),
-      queryRunner: jest.fn()
+      queryRunner: jest.fn(),
     } as unknown as MockRepository<Comment>;
 
     const mockPhotoRepository: MockRepository<Photo> = {
@@ -215,7 +233,7 @@ describe('CommentService', () => {
       decrement: jest.fn(),
       exist: jest.fn(),
       metadata: createEntityMetadata(Photo),
-      manager: {} as any,
+      manager: {} as Repository<Photo>['manager'],
       hasId: jest.fn(),
       getId: jest.fn(),
       target: Photo,
@@ -235,7 +253,7 @@ describe('CommentService', () => {
       maximum: jest.fn(),
       findOneOrFail: jest.fn(),
       findOneByOrFail: jest.fn(),
-      queryRunner: jest.fn()
+      queryRunner: jest.fn(),
     } as unknown as MockRepository<Photo>;
 
     const module: TestingModule = await Test.createTestingModule({

--- a/src/interaction/services/like.service.spec.ts
+++ b/src/interaction/services/like.service.spec.ts
@@ -5,89 +5,94 @@ import { LikeService } from './like.service';
 import { Like } from '../../domain/entities/like.entity';
 import { Photo } from '../../domain/entities/photo.entity';
 import { CreateLikeDto } from '../dtos/create-like.dto';
-import { Repository, ObjectLiteral, EntityMetadata, EntityTarget } from 'typeorm';
+import {
+  Repository,
+  ObjectLiteral,
+  EntityMetadata,
+  EntityTarget,
+} from 'typeorm';
 
-const createEntityMetadata = (entity: any): EntityMetadata => ({
-  "@instanceof": Symbol.for("EntityMetadata"),
-  connection: {} as any,
-  subscribers: [],
-  target: entity,
-  tableMetadataArgs: {} as any,
-  table: {} as any,
-  columns: [],
-  relations: [],
-  relationIds: [],
-  relationCounts: [],
-  indices: [],
-  uniques: [],
-  checks: [],
-  exclusions: [],
-  embeddeds: [],
-  foreignKeys: [],
-  propertiesMap: {},
-  closureJunctionTable: {} as any,
-  name: entity.name.toLowerCase(),
-  tableName: entity.name.toLowerCase(),
-  tablePath: entity.name.toLowerCase(),
-  schemaPath: "public",
-  orderBy: {},
-  discriminatorValue: entity.name.toLowerCase(),
-  childEntityMetadatas: [],
-  ownColumns: [],
-  ownRelations: [],
-  ownIndices: [],
-  ownUniques: [],
-  ownChecks: [],
-  ownExclusions: [],
-  isClosure: false,
-  isJunction: false,
-  isAlwaysUsingConstructor: true,
-  isJunctionEntityMetadata: false,
-  isClosureJunctionEntityMetadata: false,
-  tableType: "regular",
-  expression: undefined,
-  dependsOn: {},
-  relationWithParentMetadata: undefined,
-  relationMetadatas: [],
-  inheritanceTree: [],
-  inheritancePattern: undefined,
-  treeType: undefined,
-  treeOptions: undefined,
-  targetName: entity.name,
-  givenTableName: entity.name.toLowerCase(),
-  fileType: "entity",
-  engine: undefined,
-  database: undefined,
-  schema: undefined,
-  synchronize: true,
-  withoutRowid: false,
-  createDateColumn: undefined,
-  updateDateColumn: undefined,
-  deleteDateColumn: undefined,
-  versionColumn: undefined,
-  discriminatorColumn: undefined,
-  treeLevelColumn: undefined,
-  nestedSetLeftColumn: undefined,
-  nestedSetRightColumn: undefined,
-  materializedPathColumn: undefined,
-  objectIdColumn: undefined,
-  parentClosureEntityMetadata: undefined,
-  parentEntityMetadata: undefined,
-  tableNameWithoutPrefix: entity.name.toLowerCase(),
-} as unknown as EntityMetadata);
+const createEntityMetadata = (
+  entity: new (...args: unknown[]) => Like | Photo,
+): EntityMetadata =>
+  ({
+    '@instanceof': Symbol.for('EntityMetadata'),
+    connection: {} as Repository<Like | Photo>['manager'],
+    subscribers: [],
+    target: entity,
+    tableMetadataArgs: {} as EntityMetadata['tableMetadataArgs'],
+    table: undefined,
+    columns: [],
+    relations: [],
+    relationIds: [],
+    relationCounts: [],
+    indices: [],
+    uniques: [],
+    checks: [],
+    exclusions: [],
+    embeddeds: [],
+    foreignKeys: [],
+    propertiesMap: {},
+    closureJunctionTable: {} as EntityMetadata['closureJunctionTable'],
+    name: entity.name.toLowerCase(),
+    tableName: entity.name.toLowerCase(),
+    tablePath: entity.name.toLowerCase(),
+    schemaPath: 'public',
+    orderBy: {},
+    discriminatorValue: entity.name.toLowerCase(),
+    childEntityMetadatas: [],
+    ownColumns: [],
+    ownRelations: [],
+    ownIndices: [],
+    ownUniques: [],
+    ownChecks: [],
+    ownExclusions: [],
+    isClosure: false,
+    isJunction: false,
+    isAlwaysUsingConstructor: true,
+    isJunctionEntityMetadata: false,
+    isClosureJunctionEntityMetadata: false,
+    tableType: 'regular',
+    expression: undefined,
+    dependsOn: {},
+    relationWithParentMetadata: undefined,
+    relationMetadatas: [],
+    inheritanceTree: [],
+    inheritancePattern: undefined,
+    treeType: undefined,
+    treeOptions: undefined,
+    targetName: entity.name,
+    givenTableName: entity.name.toLowerCase(),
+    fileType: 'entity',
+    engine: undefined,
+    database: undefined,
+    schema: undefined,
+    synchronize: true,
+    withoutRowid: false,
+    createDateColumn: undefined,
+    updateDateColumn: undefined,
+    deleteDateColumn: undefined,
+    versionColumn: undefined,
+    discriminatorColumn: undefined,
+    treeLevelColumn: undefined,
+    nestedSetLeftColumn: undefined,
+    nestedSetRightColumn: undefined,
+    materializedPathColumn: undefined,
+    objectIdColumn: undefined,
+    parentClosureEntityMetadata: undefined,
+    parentEntityMetadata: undefined,
+    tableNameWithoutPrefix: entity.name.toLowerCase(),
+  }) as unknown as EntityMetadata;
 
-type MockType<T> = {
-  [P in keyof T]: P extends 'metadata' | 'manager' | 'target' ? T[P] : jest.Mock;
-};
-
+// Type for repository methods
 type MockRepository<T extends ObjectLiteral> = {
   [P in keyof Repository<T>]: P extends 'metadata'
     ? EntityMetadata
     : P extends 'manager'
-    ? Repository<T>['manager']
-    : P extends 'target'
-    ? EntityTarget<T>
-    : jest.Mock;
+      ? Repository<T>['manager']
+      : P extends 'target'
+        ? EntityTarget<T>
+        : jest.Mock;
 } & {
   softRemove: jest.Mock;
   restore: jest.Mock;
@@ -142,7 +147,7 @@ describe('LikeService', () => {
       decrement: jest.fn(),
       exist: jest.fn(),
       metadata: createEntityMetadata(Like),
-      manager: {} as any,
+      manager: {} as Repository<Like>['manager'],
       hasId: jest.fn(),
       getId: jest.fn(),
       target: jest.fn().mockReturnValue(Like),
@@ -166,7 +171,7 @@ describe('LikeService', () => {
       maximum: jest.fn(),
       findOneOrFail: jest.fn(),
       findOneByOrFail: jest.fn(),
-      queryRunner: jest.fn()
+      queryRunner: jest.fn(),
     };
 
     const mockPhotoRepository: MockRepository<Photo> = {
@@ -189,7 +194,7 @@ describe('LikeService', () => {
       decrement: jest.fn(),
       exist: jest.fn(),
       metadata: createEntityMetadata(Photo),
-      manager: {} as any,
+      manager: {} as Repository<Photo>['manager'],
       hasId: jest.fn(),
       getId: jest.fn(),
       target: Photo,
@@ -213,7 +218,7 @@ describe('LikeService', () => {
       softRemove: jest.fn(),
       restore: jest.fn(),
       exists: jest.fn(),
-      existsBy: jest.fn()
+      existsBy: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/src/notification/services/notification.service.spec.ts
+++ b/src/notification/services/notification.service.spec.ts
@@ -5,89 +5,95 @@ import {
   Notification,
   NotificationType,
 } from '../../domain/entities/notification.entity';
-import { Repository, ObjectLiteral, EntityMetadata, EntityTarget } from 'typeorm';
+import {
+  Repository,
+  EntityMetadata,
+  ObjectLiteral,
+  EntityTarget,
+} from 'typeorm';
 
-const createEntityMetadata = (entity: any): EntityMetadata => ({
-  "@instanceof": Symbol.for("EntityMetadata"),
-  connection: {} as any,
-  subscribers: [],
-  target: entity,
-  tableMetadataArgs: {} as any,
-  table: {} as any,
-  columns: [],
-  relations: [],
-  relationIds: [],
-  relationCounts: [],
-  indices: [],
-  uniques: [],
-  checks: [],
-  exclusions: [],
-  embeddeds: [],
-  foreignKeys: [],
-  propertiesMap: {},
-  closureJunctionTable: {} as any,
-  name: entity.name.toLowerCase(),
-  tableName: entity.name.toLowerCase(),
-  tablePath: entity.name.toLowerCase(),
-  schemaPath: "public",
-  orderBy: {},
-  discriminatorValue: entity.name.toLowerCase(),
-  childEntityMetadatas: [],
-  ownColumns: [],
-  ownRelations: [],
-  ownIndices: [],
-  ownUniques: [],
-  ownChecks: [],
-  ownExclusions: [],
-  isClosure: false,
-  isJunction: false,
-  isAlwaysUsingConstructor: true,
-  isJunctionEntityMetadata: false,
-  isClosureJunctionEntityMetadata: false,
-  tableType: "regular",
-  expression: undefined,
-  dependsOn: {},
-  relationWithParentMetadata: undefined,
-  relationMetadatas: [],
-  inheritanceTree: [],
-  inheritancePattern: undefined,
-  treeType: undefined,
-  treeOptions: undefined,
-  targetName: entity.name,
-  givenTableName: entity.name.toLowerCase(),
-  fileType: "entity",
-  engine: undefined,
-  database: undefined,
-  schema: undefined,
-  synchronize: true,
-  withoutRowid: false,
-  createDateColumn: undefined,
-  updateDateColumn: undefined,
-  deleteDateColumn: undefined,
-  versionColumn: undefined,
-  discriminatorColumn: undefined,
-  treeLevelColumn: undefined,
-  nestedSetLeftColumn: undefined,
-  nestedSetRightColumn: undefined,
-  materializedPathColumn: undefined,
-  objectIdColumn: undefined,
-  parentClosureEntityMetadata: undefined,
-  parentEntityMetadata: undefined,
-  tableNameWithoutPrefix: entity.name.toLowerCase(),
-} as unknown as EntityMetadata);
+const createEntityMetadata = (
+  entity: new (...args: unknown[]) => Notification,
+): EntityMetadata =>
+  ({
+    '@instanceof': Symbol.for('EntityMetadata'),
+    connection: {} as Repository<Notification>['manager'],
+    subscribers: [],
+    target: entity,
+    tableMetadataArgs: {} as EntityMetadata['tableMetadataArgs'],
+    table: undefined,
+    columns: [],
+    relations: [],
+    relationIds: [],
+    relationCounts: [],
+    indices: [],
+    uniques: [],
+    checks: [],
+    exclusions: [],
+    embeddeds: [],
+    foreignKeys: [],
+    propertiesMap: {},
+    closureJunctionTable: {} as EntityMetadata['closureJunctionTable'],
+    name: entity.name.toLowerCase(),
+    tableName: entity.name.toLowerCase(),
+    tablePath: entity.name.toLowerCase(),
+    schemaPath: 'public',
+    orderBy: {},
+    discriminatorValue: entity.name.toLowerCase(),
+    childEntityMetadatas: [],
+    ownColumns: [],
+    ownRelations: [],
+    ownIndices: [],
+    ownUniques: [],
+    ownChecks: [],
+    ownExclusions: [],
+    isClosure: false,
+    isJunction: false,
+    isAlwaysUsingConstructor: true,
+    isJunctionEntityMetadata: false,
+    isClosureJunctionEntityMetadata: false,
+    tableType: 'regular',
+    expression: undefined,
+    dependsOn: {},
+    relationWithParentMetadata: undefined,
+    relationMetadatas: [],
+    inheritanceTree: [],
+    inheritancePattern: undefined,
+    treeType: undefined,
+    treeOptions: undefined,
+    targetName: entity.name,
+    givenTableName: entity.name.toLowerCase(),
+    fileType: 'entity',
+    engine: undefined,
+    database: undefined,
+    schema: undefined,
+    synchronize: true,
+    withoutRowid: false,
+    createDateColumn: undefined,
+    updateDateColumn: undefined,
+    deleteDateColumn: undefined,
+    versionColumn: undefined,
+    discriminatorColumn: undefined,
+    treeLevelColumn: undefined,
+    nestedSetLeftColumn: undefined,
+    nestedSetRightColumn: undefined,
+    materializedPathColumn: undefined,
+    objectIdColumn: undefined,
+    parentClosureEntityMetadata: undefined,
+    parentEntityMetadata: undefined,
+    tableNameWithoutPrefix: entity.name.toLowerCase(),
+  }) as unknown as EntityMetadata;
 
-type MockType<T> = {
-  [P in keyof T]: P extends 'metadata' | 'manager' | 'target' ? T[P] : jest.Mock;
-};
+// Type for repository methods
 
 type MockRepository<T extends ObjectLiteral> = {
   [P in keyof Repository<T>]: P extends 'metadata'
     ? EntityMetadata
     : P extends 'manager'
-    ? Repository<T>['manager']
-    : P extends 'target'
-    ? EntityTarget<T>
-    : jest.Mock;
+      ? Repository<T>['manager']
+      : P extends 'target'
+        ? EntityTarget<T>
+        : jest.Mock;
 } & {
   softRemove: jest.Mock;
   restore: jest.Mock;
@@ -204,7 +210,7 @@ describe('NotificationService', () => {
     decrement: jest.fn(),
     exist: jest.fn(),
     metadata: createEntityMetadata(Notification),
-    manager: {} as any,
+    manager: {} as Repository<Notification>['manager'],
     hasId: jest.fn(),
     getId: jest.fn(),
     target: jest.fn().mockReturnValue(Notification),
@@ -228,7 +234,7 @@ describe('NotificationService', () => {
     maximum: jest.fn(),
     findOneOrFail: jest.fn(),
     findOneByOrFail: jest.fn(),
-    queryRunner: jest.fn()
+    queryRunner: jest.fn(),
   };
 
   beforeEach(async () => {

--- a/src/photo/services/storage.service.spec.ts
+++ b/src/photo/services/storage.service.spec.ts
@@ -10,10 +10,10 @@ interface MockS3Instance {
   deleteObject: jest.Mock;
 }
 
-const mockS3Instance: MockS3Instance = {
+const mockS3Instance = {
   upload: jest.fn(),
   deleteObject: jest.fn(),
-};
+} as MockS3Instance;
 
 jest.mock('aws-sdk', () => ({
   S3: jest.fn(() => mockS3Instance),
@@ -23,14 +23,14 @@ describe('StorageService', () => {
   let service: StorageService;
 
   const mockConfigService = {
-    get: jest.fn((key: string) => {
-      const config = {
+    get: jest.fn((key: string): string | undefined => {
+      const config: Record<string, string> = {
         AWS_S3_BUCKET: 'test-bucket',
         AWS_REGION: 'us-east-1',
         AWS_ACCESS_KEY_ID: 'test-key',
         AWS_SECRET_ACCESS_KEY: 'test-secret',
       };
-      return config[key] as string;
+      return config[key];
     }),
   };
 
@@ -105,7 +105,7 @@ describe('StorageService', () => {
       });
       expect(mockS3Instance.upload).toHaveBeenCalledWith({
         Bucket: 'test-bucket',
-        Key: expect.any(String),
+        Key: expect.any(String) as string,
         Body: mockFile.buffer,
         ContentType: mockFile.mimetype,
         ACL: 'public-read',

--- a/src/photo/services/storage.service.ts
+++ b/src/photo/services/storage.service.ts
@@ -2,7 +2,6 @@ import { Injectable, BadRequestException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as AWS from 'aws-sdk';
 import { UploadResult } from '../interfaces/storage-config.interface';
-import { ConfigModule } from '@nestjs/config';
 
 @Injectable()
 export class StorageService {

--- a/src/user/services/user.service.ts
+++ b/src/user/services/user.service.ts
@@ -51,7 +51,7 @@ export class UserService {
       if (error instanceof NotFoundException) {
         throw error;
       }
-      throw new Error(error.message);
+      throw new Error(error instanceof Error ? error.message : 'Unknown error');
     }
   }
 


### PR DESCRIPTION
This pull request includes several changes to improve the code quality and testing infrastructure. The most significant changes involve adding linting steps to the CI workflows, enhancing the `package.json` lint script, and refactoring various test files to improve mock implementations and type definitions.

### CI Workflow Enhancements:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR37-R39): Added a linting step to the CI workflow to ensure code quality.
* [`.github/workflows/develop-check.yml`](diffhunk://#diff-8b031c8da635bb56084f84d315c597326d234a9dfbded7f82591cbd215ab0e8cR39-R41): Added a linting step to the develop-check workflow to catch issues earlier in the development process.

### Lint Script Improvement:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L19-R19): Enhanced the lint script to automatically fix issues where possible by adding the `--fix` flag.

### Test Refactoring:
* [`src/app.module.spec.ts`](diffhunk://#diff-9e3ae7da48a3b6f46ededcce2ecd1c3149b00ae04934c6a212d26bbb7026fb50L2-R105): Refactored the test setup to use mock implementations for feature modules and simplified the configuration of `ConfigService` and `DataSource`.
* [`src/auth/strategies/jwt.strategy.spec.ts`](diffhunk://#diff-9ef1ef45a9ee8c36e08383bc7492fe9c556ef67e5556dbebdbae9c1adffd180cL158-L162): Simplified the test for `JwtStrategy` by removing an unnecessary variable assignment.
* [`src/feed/services/feed.service.spec.ts`](diffhunk://#diff-e51519f1b9dbd4138d913b2c7d372eb26b6757320030a1667058cc70c327df36L3-R115): Improved the mock repository type definitions and added additional mock methods to better simulate the `typeorm` repository behavior. [[1]](diffhunk://#diff-e51519f1b9dbd4138d913b2c7d372eb26b6757320030a1667058cc70c327df36L3-R115) [[2]](diffhunk://#diff-e51519f1b9dbd4138d913b2c7d372eb26b6757320030a1667058cc70c327df36R138-R148) [[3]](diffhunk://#diff-e51519f1b9dbd4138d913b2c7d372eb26b6757320030a1667058cc70c327df36L63-R167) [[4]](diffhunk://#diff-e51519f1b9dbd4138d913b2c7d372eb26b6757320030a1667058cc70c327df36L77-R198) [[5]](diffhunk://#diff-e51519f1b9dbd4138d913b2c7d372eb26b6757320030a1667058cc70c327df36L102-R217) [[6]](diffhunk://#diff-e51519f1b9dbd4138d913b2c7d372eb26b6757320030a1667058cc70c327df36L116-R230)
* [`src/interaction/services/comment.service.spec.ts`](diffhunk://#diff-d2f18cedb2ed3427245a0956d7d659dc3c76759fafdcb47b9ab7d185fdc2efd3L7-R25): Refactored the entity metadata creation and mock repository type definitions to improve test clarity and maintainability. [[1]](diffhunk://#diff-d2f18cedb2ed3427245a0956d7d659dc3c76759fafdcb47b9ab7d185fdc2efd3L7-R25) [[2]](diffhunk://#diff-d2f18cedb2ed3427245a0956d7d659dc3c76759fafdcb47b9ab7d185fdc2efd3L29-R41) [[3]](diffhunk://#diff-d2f18cedb2ed3427245a0956d7d659dc3c76759fafdcb47b9ab7d185fdc2efd3L48-R56) [[4]](diffhunk://#diff-d2f18cedb2ed3427245a0956d7d659dc3c76759fafdcb47b9ab7d185fdc2efd3L59-R67) [[5]](diffhunk://#diff-d2f18cedb2ed3427245a0956d7d659dc3c76759fafdcb47b9ab7d185fdc2efd3L78-R88) [[6]](diffhunk://#diff-d2f18cedb2ed3427245a0956d7d659dc3c76759fafdcb47b9ab7d185fdc2efd3R98-R109) [[7]](diffhunk://#diff-d2f18cedb2ed3427245a0956d7d659dc3c76759fafdcb47b9ab7d185fdc2efd3L164-R182) [[8]](diffhunk://#diff-d2f18cedb2ed3427245a0956d7d659dc3c76759fafdcb47b9ab7d185fdc2efd3L188-R206) [[9]](diffhunk://#diff-d2f18cedb2ed3427245a0956d7d659dc3c76759fafdcb47b9ab7d185fdc2efd3L218-R236)