### PR TITLE
Develop

### DIFF
--- a/.github/workflows/develop-tests.yml
+++ b/.github/workflows/develop-tests.yml
@@ -36,7 +36,9 @@ jobs:
 
     - name: Install dependencies
       run: npm ci
-
+      #    run linting
+    - name: Run Lint
+      run: npm run lint
 
     - name: Run tests
       run: npm run test

--- a/src/auth/interfaces/UserRequest.ts
+++ b/src/auth/interfaces/UserRequest.ts
@@ -1,0 +1,5 @@
+import { User } from '../../domain/entities/user.entity';
+
+export interface RequestWithUser extends Request {
+  user: User;
+}

--- a/src/domain/entities/photo.entity.ts
+++ b/src/domain/entities/photo.entity.ts
@@ -30,7 +30,7 @@ export class Photo {
   @Column({ nullable: true })
   caption: string;
 
-  @Column('text', { array: true })
+  @Column('text', { array: true, default: [] })
   hashtags: string[];
 
   @CreateDateColumn()

--- a/src/feed/controllers/feed.controller.spec.ts
+++ b/src/feed/controllers/feed.controller.spec.ts
@@ -4,6 +4,7 @@ import { FeedController } from './feed.controller';
 import { FeedService } from '../services/feed.service';
 import { FeedQueryDto } from '../dtos/feed-query.dto';
 import '@jest/globals';
+import { RequestWithUser } from '../../auth/interfaces/UserRequest';
 
 describe('FeedController', () => {
   let controller: FeedController;
@@ -39,6 +40,15 @@ describe('FeedController', () => {
       },
     }),
   };
+  const mockRequest = {
+    user: {
+      id: '1',
+      username: 'testuser',
+      email: 'test@example.com',
+    },
+    headers: {},
+    body: {},
+  } as RequestWithUser;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -63,15 +73,16 @@ describe('FeedController', () => {
   });
 
   describe('getFeed', () => {
-    const mockRequest: { user: { sub: string } } = {
-      user: { sub: '1' },
-    };
-
     it('should throw BadRequestException when user data is invalid', async () => {
-      const invalidRequest = { user: { sub: '' } };
-      await expect(
-        controller.getFeed(invalidRequest as { user: { sub: string } }, {}),
-      ).rejects.toThrow(BadRequestException);
+      const invalidRequest = {
+        user: { id: '' },
+        headers: {},
+        body: {},
+      } as RequestWithUser;
+
+      await expect(controller.getFeed(invalidRequest, {})).rejects.toThrow(
+        BadRequestException,
+      );
     });
 
     const mockQuery: FeedQueryDto = {
@@ -112,12 +123,9 @@ describe('FeedController', () => {
     });
 
     it('should handle invalid user in request', async () => {
-      const invalidRequest = { user: {} };
+      const invalidRequest = { user: {} } as RequestWithUser;
       await expect(
-        controller.getFeed(
-          invalidRequest as { user: { sub: string } },
-          mockQuery,
-        ),
+        controller.getFeed(invalidRequest, mockQuery),
       ).rejects.toThrow();
     });
 

--- a/src/feed/controllers/feed.controller.ts
+++ b/src/feed/controllers/feed.controller.ts
@@ -16,6 +16,7 @@ import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { FeedService } from '../services/feed.service';
 import { FeedQueryDto } from '../dtos/feed-query.dto';
 import { PhotoResponseDto } from '../../photo/dtos/photo-response.dto';
+import { RequestWithUser } from '../../auth/interfaces/UserRequest';
 
 @ApiTags('feed')
 @Controller('feed')
@@ -32,13 +33,10 @@ export class FeedController {
     type: PhotoResponseDto,
     isArray: true,
   })
-  async getFeed(
-    @Request() req: { user: { sub: string } },
-    @Query() query: FeedQueryDto,
-  ) {
-    if (!req?.user?.sub) {
+  async getFeed(@Request() req: RequestWithUser, @Query() query: FeedQueryDto) {
+    if (!req?.user?.id) {
       throw new BadRequestException('Invalid user data');
     }
-    return this.feedService.getFeed(req.user.sub, query);
+    return this.feedService.getFeed(req.user.id, query);
   }
 }

--- a/src/interaction/controllers/comment.controller.spec.ts
+++ b/src/interaction/controllers/comment.controller.spec.ts
@@ -7,6 +7,7 @@ import { Comment } from '../../domain/entities/comment.entity';
 import { Photo } from '../../domain/entities/photo.entity';
 import { User } from '../../domain/entities/user.entity';
 import '@jest/globals';
+import { RequestWithUser } from '../../auth/interfaces/UserRequest';
 
 describe('CommentController', () => {
   let controller: CommentController;
@@ -24,8 +25,14 @@ describe('CommentController', () => {
   };
 
   const mockRequest = {
-    user: { sub: mockUser.sub },
-  };
+    user: {
+      id: mockUser.sub,
+      username: mockUser.username,
+      email: mockUser.email,
+    },
+    headers: {},
+    body: {},
+  } as RequestWithUser;
 
   const mockUserEntity: User = {
     id: mockUser.sub,
@@ -191,7 +198,11 @@ describe('CommentController', () => {
     });
 
     it('should handle missing user in request', async () => {
-      const invalidRequest = { user: { sub: '' } };
+      const invalidRequest = {
+        user: { id: '' },
+        headers: {},
+        body: {},
+      } as RequestWithUser;
       mockCommentService.create.mockRejectedValueOnce(
         new Error('Invalid user ID'),
       );
@@ -393,14 +404,14 @@ describe('CommentController', () => {
     });
 
     it('should handle invalid request data', async () => {
-      const invalidRequest = { user: {} };
+      const invalidRequest = {
+        user: null, // This should trigger validation
+        headers: {},
+        body: {},
+      } as unknown as RequestWithUser;
 
       await expect(
-        controller.create(
-          invalidRequest as { user: { sub: string } },
-          '1',
-          createCommentDto,
-        ),
+        controller.create(invalidRequest, '1', createCommentDto),
       ).rejects.toThrow();
     });
   });

--- a/src/interaction/controllers/comment.controller.ts
+++ b/src/interaction/controllers/comment.controller.ts
@@ -17,6 +17,7 @@ import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { CommentService } from '../services/comment.service';
 import { CreateCommentDto } from '../dtos/create-comment.dto';
 import { CommentResponseDto } from '../dtos/comment-response.dto';
+import { RequestWithUser } from '../../auth/interfaces/UserRequest';
 
 @ApiTags('comments')
 @Controller('comments')
@@ -33,11 +34,11 @@ export class CommentController {
     type: CommentResponseDto,
   })
   async create(
-    @Request() req: { user: { sub: string } },
+    @Request() req: RequestWithUser,
     @Param('photoId') photoId: string,
     @Body() createCommentDto: CreateCommentDto,
   ) {
-    return this.commentService.create(req.user.sub, photoId, createCommentDto);
+    return this.commentService.create(req.user.id, photoId, createCommentDto);
   }
 
   @Get('photo/:photoId')

--- a/src/interaction/controllers/like.controller.spec.ts
+++ b/src/interaction/controllers/like.controller.spec.ts
@@ -5,6 +5,7 @@ import { CreateLikeDto } from '../dtos/create-like.dto';
 import { Like } from '../../domain/entities/like.entity';
 import { User } from '../../domain/entities/user.entity';
 import { Photo } from '../../domain/entities/photo.entity';
+import { RequestWithUser } from '../../auth/interfaces/UserRequest';
 // Removed unused import LikeResponseDto
 
 describe('LikeController', () => {
@@ -82,9 +83,15 @@ describe('LikeController', () => {
       photoId: '1',
     };
 
-    const mockRequest: { user: { sub: string } } = {
-      user: { sub: mockUser.id },
-    };
+    const mockRequest = {
+      user: {
+        id: mockUser.id,
+        username: mockUser.username,
+        email: mockUser.email,
+      },
+      headers: {},
+      body: {},
+    } as RequestWithUser;
 
     it('should create a like successfully', async (): Promise<void> => {
       const createSpy = jest.spyOn(likeService, 'create');
@@ -110,9 +117,15 @@ describe('LikeController', () => {
   });
 
   describe('remove', () => {
-    const mockRequest: { user: { sub: string } } = {
-      user: { sub: mockUser.id },
-    };
+    const mockRequest = {
+      user: {
+        id: mockUser.id,
+        username: mockUser.username,
+        email: mockUser.email,
+      },
+      headers: {},
+      body: {},
+    } as RequestWithUser;
 
     it('should remove a like successfully', async (): Promise<void> => {
       const removeSpy = jest.spyOn(likeService, 'remove');

--- a/src/interaction/controllers/like.controller.ts
+++ b/src/interaction/controllers/like.controller.ts
@@ -18,6 +18,7 @@ import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { LikeService } from '../services/like.service';
 import { CreateLikeDto } from '../dtos/create-like.dto';
 import { LikeResponseDto } from '../dtos/like-response.dto';
+import { RequestWithUser } from '../../auth/interfaces/UserRequest';
 
 @ApiTags('likes')
 @Controller('likes')
@@ -34,20 +35,20 @@ export class LikeController {
     type: LikeResponseDto,
   })
   async create(
-    @Request() req: { user: { sub: string } },
+    @Request() req: RequestWithUser,
     @Body() createLikeDto: CreateLikeDto,
   ) {
-    return this.likeService.create(req.user.sub, createLikeDto);
+    return this.likeService.create(req.user.id, createLikeDto);
   }
 
   @Delete(':photoId')
   @ApiOperation({ summary: 'Unlike a photo' })
   @ApiResponse({ status: 200, description: 'Photo unliked successfully' })
   async remove(
-    @Request() req: { user: { sub: string } },
+    @Request() req: RequestWithUser,
     @Param('photoId') photoId: string,
   ) {
-    return this.likeService.remove(req.user.sub, photoId);
+    return this.likeService.remove(req.user.id, photoId);
   }
 
   @Get('photo/:photoId')

--- a/src/notification/controllers/notification.controller.spec.ts
+++ b/src/notification/controllers/notification.controller.spec.ts
@@ -6,6 +6,7 @@ import {
   Notification,
 } from '../../domain/entities/notification.entity';
 import '@jest/globals';
+import { RequestWithUser } from '../../auth/interfaces/UserRequest';
 
 describe('NotificationController', () => {
   let controller: NotificationController;
@@ -110,7 +111,13 @@ describe('NotificationController', () => {
   });
 
   describe('getUserNotifications', () => {
-    const mockRequest = { user: { sub: '1' } };
+    const mockRequest = {
+      user: {
+        id: '1',
+      },
+      headers: {},
+      body: {},
+    } as RequestWithUser;
 
     it('should return user notifications', async () => {
       const result = await controller.getUserNotifications(mockRequest);
@@ -135,7 +142,13 @@ describe('NotificationController', () => {
   });
 
   describe('markAsRead', () => {
-    const mockRequest = { user: { sub: '1' } };
+    const mockRequest = {
+      user: {
+        id: '1',
+      },
+      headers: {},
+      body: {},
+    } as RequestWithUser;
 
     it('should mark notification as read', async () => {
       await controller.markAsRead(mockRequest, '1');
@@ -156,7 +169,13 @@ describe('NotificationController', () => {
   });
 
   describe('markAllAsRead', () => {
-    const mockRequest = { user: { sub: '1' } };
+    const mockRequest = {
+      user: {
+        id: '1',
+      },
+      headers: {},
+      body: {},
+    } as RequestWithUser;
 
     it('should mark all notifications as read', async () => {
       await controller.markAllAsRead(mockRequest);

--- a/src/notification/controllers/notification.controller.ts
+++ b/src/notification/controllers/notification.controller.ts
@@ -14,6 +14,7 @@ import {
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { NotificationService } from '../services/notification.service';
+import { RequestWithUser } from '../../auth/interfaces/UserRequest';
 
 @ApiTags('notifications')
 @Controller('notifications')
@@ -25,26 +26,26 @@ export class NotificationController {
   @Get()
   @ApiOperation({ summary: 'Get user notifications' })
   @ApiResponse({ status: 200, description: 'Returns list of notifications' })
-  async getUserNotifications(@Request() req: { user: { sub: string } }) {
-    return this.notificationService.getUserNotifications(req.user.sub);
+  async getUserNotifications(@Request() req: RequestWithUser) {
+    return this.notificationService.getUserNotifications(req.user.id);
   }
 
   @Post(':id/read')
   @ApiOperation({ summary: 'Mark notification as read' })
   @ApiResponse({ status: 200, description: 'Notification marked as read' })
   async markAsRead(
-    @Request() req: { user: { sub: string } },
+    @Request() req: RequestWithUser,
     @Param('id') notificationId: string,
   ) {
-    await this.notificationService.markAsRead(req.user.sub, notificationId);
+    await this.notificationService.markAsRead(req.user.id, notificationId);
     return { message: 'Notification marked as read' };
   }
 
   @Post('read-all')
   @ApiOperation({ summary: 'Mark all notifications as read' })
   @ApiResponse({ status: 200, description: 'All notifications marked as read' })
-  async markAllAsRead(@Request() req: { user: { sub: string } }) {
-    await this.notificationService.markAllAsRead(req.user.sub);
+  async markAllAsRead(@Request() req: RequestWithUser) {
+    await this.notificationService.markAllAsRead(req.user.id);
     return { message: 'All notifications marked as read' };
   }
 }

--- a/src/photo/controllers/photo.controller.spec.ts
+++ b/src/photo/controllers/photo.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { PhotoController } from './photo.controller';
 import { PhotoService } from '../services/photo.service';
 import { CreatePhotoDto } from '../dtos/create-photo.dto';
+import { RequestWithUser } from '../../auth/interfaces/UserRequest';
 
 describe('PhotoController', () => {
   let controller: PhotoController;
@@ -72,11 +73,13 @@ describe('PhotoController', () => {
 
     const mockRequest = {
       user: {
-        sub: mockUser.id,
-        email: mockUser.email,
+        id: mockUser.id,
         username: mockUser.username,
+        email: mockUser.email,
       },
-    };
+      headers: {},
+      body: {},
+    } as RequestWithUser;
 
     it('should create photo successfully', async () => {
       const result = await controller.create(
@@ -109,8 +112,14 @@ describe('PhotoController', () => {
 
   describe('findAll', () => {
     const mockRequest = {
-      user: { sub: mockUser.id },
-    };
+      user: {
+        id: mockUser.id,
+        username: mockUser.username,
+        email: mockUser.email,
+      },
+      headers: {},
+      body: {},
+    } as RequestWithUser;
 
     it('should return all photos for user', async () => {
       const result = await controller.findAll(mockRequest);
@@ -141,8 +150,14 @@ describe('PhotoController', () => {
 
   describe('remove', () => {
     const mockRequest = {
-      user: { sub: mockUser.id },
-    };
+      user: {
+        id: mockUser.id,
+        username: mockUser.username,
+        email: mockUser.email,
+      },
+      headers: {},
+      body: {},
+    } as RequestWithUser;
 
     it('should remove photo successfully', async () => {
       await controller.remove(mockRequest, mockPhoto.id);

--- a/src/photo/controllers/photo.controller.ts
+++ b/src/photo/controllers/photo.controller.ts
@@ -23,6 +23,7 @@ import { PhotoService } from '../services/photo.service';
 import { CreatePhotoDto } from '../dtos/create-photo.dto';
 import { PhotoResponseDto } from '../dtos/photo-response.dto';
 import { User } from '../../domain/entities/user.entity';
+import { RequestWithUser } from '../../auth/interfaces/UserRequest';
 
 @ApiTags('photos')
 @Controller('photos')
@@ -41,12 +42,12 @@ export class PhotoController {
   @ApiConsumes('multipart/form-data')
   @UseInterceptors(FileInterceptor('file'))
   async create(
-    @Request() req: { user: { sub: string; email: string; username: string } },
+    @Request() req: RequestWithUser,
     @Body() createPhotoDto: CreatePhotoDto,
     @UploadedFile() file: Express.Multer.File,
   ) {
     const user = {
-      id: req.user.sub,
+      id: req.user.id,
       email: req.user.email,
       username: req.user.username,
     } as User;
@@ -60,17 +61,14 @@ export class PhotoController {
     description: 'List of photos',
     type: [PhotoResponseDto],
   })
-  async findAll(@Request() req: { user: { sub: string } }) {
-    return this.photoService.findAllByUser(req.user.sub);
+  async findAll(@Request() req: RequestWithUser) {
+    return this.photoService.findAllByUser(req.user.id);
   }
 
   @Delete(':id')
   @ApiOperation({ summary: 'Delete a photo' })
   @ApiResponse({ status: 200, description: 'Photo deleted successfully' })
-  async remove(
-    @Request() req: { user: { sub: string } },
-    @Param('id') id: string,
-  ) {
-    return this.photoService.remove(req.user.sub, id);
+  async remove(@Request() req: RequestWithUser, @Param('id') id: string) {
+    return this.photoService.remove(req.user.id, id);
   }
 }

--- a/src/photo/dtos/create-photo.dto.ts
+++ b/src/photo/dtos/create-photo.dto.ts
@@ -1,5 +1,7 @@
+// create-photo.dto.ts
 import { IsString, IsArray, IsOptional } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 
 export class CreatePhotoDto {
   @ApiProperty({ type: 'string', format: 'binary' })
@@ -13,5 +15,16 @@ export class CreatePhotoDto {
   @ApiProperty({ type: [String], required: false })
   @IsArray()
   @IsOptional()
+  @Transform(({ value }): string[] => {
+    if (typeof value === 'string') {
+      try {
+        const parsed = JSON.parse(value) as string | string[];
+        return Array.isArray(parsed) ? parsed : [parsed];
+      } catch {
+        return [value];
+      }
+    }
+    return Array.isArray(value) ? value : [];
+  })
   hashtags?: string[];
 }

--- a/src/photo/services/photo.service.ts
+++ b/src/photo/services/photo.service.ts
@@ -49,7 +49,10 @@ export class PhotoService {
       filename: file.originalname,
       url: uploadResult.url,
       caption: createPhotoDto.caption,
-      hashtags: createPhotoDto.hashtags || [],
+      hashtags:
+        typeof createPhotoDto.hashtags === 'string'
+          ? (JSON.parse(createPhotoDto.hashtags) as string[])
+          : (createPhotoDto.hashtags ?? []),
     });
 
     return this.photoRepository.save(photo);

--- a/src/photo/services/storage.service.ts
+++ b/src/photo/services/storage.service.ts
@@ -53,7 +53,6 @@ export class StorageService {
       Key: key,
       Body: file.buffer,
       ContentType: file.mimetype,
-      ACL: 'public-read',
     };
 
     const uploadResult = await this.s3.upload(params).promise();

--- a/src/user/controllers/user.controller.spec.ts
+++ b/src/user/controllers/user.controller.spec.ts
@@ -3,6 +3,7 @@ import { UserController } from './user.controller';
 import { UserService } from '../services/user.service';
 // Removed unused import UpdateProfileDto
 import { UserProfileDto } from '../dtos/user-profile.dto';
+import { RequestWithUser } from '../../auth/interfaces/UserRequest';
 
 describe('UserController', () => {
   let controller: UserController;
@@ -27,9 +28,11 @@ describe('UserController', () => {
 
   const mockRequest = {
     user: {
-      sub: '1',
+      id: '1',
     },
-  };
+    headers: {},
+    body: {},
+  } as RequestWithUser;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -70,7 +73,7 @@ describe('UserController', () => {
 
       const followUserSpy = jest.spyOn(userService, 'followUser');
       expect(followUserSpy).toHaveBeenCalledWith(
-        mockRequest.user.sub,
+        mockRequest.user.id,
         'usertofollow',
       );
       followUserSpy.mockRestore();
@@ -83,7 +86,7 @@ describe('UserController', () => {
 
       const unfollowUserSpy = jest.spyOn(userService, 'unfollowUser');
       expect(unfollowUserSpy).toHaveBeenCalledWith(
-        mockRequest.user.sub,
+        mockRequest.user.id,
         'userunfollow',
       );
       unfollowUserSpy.mockRestore();
@@ -105,7 +108,7 @@ describe('UserController', () => {
       const updateProfileSpy = jest.spyOn(userService, 'updateProfile');
       expect(result).toBe(mockUserProfile);
       expect(updateProfileSpy).toHaveBeenCalledWith(
-        mockRequest.user.sub,
+        mockRequest.user.id,
         updateProfileDto,
       );
       updateProfileSpy.mockRestore();

--- a/src/user/controllers/user.controller.ts
+++ b/src/user/controllers/user.controller.ts
@@ -55,10 +55,10 @@ export class UserController {
   @ApiOperation({ summary: 'Unfollow a user' })
   @ApiResponse({ status: 200, description: 'Successfully unfollowed user' })
   async unfollowUser(
-    @Request() req: { user: { sub: string } },
+    @Request() req: RequestWithUser,
     @Param('username') username: string,
   ): Promise<void> {
-    await this.userService.unfollowUser(req.user.sub, username);
+    await this.userService.unfollowUser(req.user.id, username);
   }
 
   @Put('profile')
@@ -69,9 +69,9 @@ export class UserController {
     type: UserProfileDto,
   })
   async updateProfile(
-    @Request() req: { user: { sub: string } },
+    @Request() req: RequestWithUser,
     @Body() updateProfileDto: UpdateProfileDto,
   ): Promise<UserProfileDto> {
-    return this.userService.updateProfile(req.user.sub, updateProfileDto);
+    return this.userService.updateProfile(req.user.id, updateProfileDto);
   }
 }

--- a/src/user/controllers/user.controller.ts
+++ b/src/user/controllers/user.controller.ts
@@ -19,6 +19,7 @@ import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { UserService } from '../services/user.service';
 import { UpdateProfileDto } from '../dtos/update-profile.dto';
 import { UserProfileDto } from '../dtos/user-profile.dto';
+import { RequestWithUser } from '../../auth/interfaces/UserRequest';
 
 @ApiTags('users')
 @Controller('users')
@@ -44,10 +45,10 @@ export class UserController {
   @ApiOperation({ summary: 'Follow a user' })
   @ApiResponse({ status: 201, description: 'Successfully followed user' })
   async followUser(
-    @Request() req: { user: { sub: string } },
+    @Request() req: RequestWithUser,
     @Param('username') username: string,
   ): Promise<void> {
-    await this.userService.followUser(req.user.sub, username);
+    await this.userService.followUser(req.user.id, username);
   }
 
   @Delete('unfollow/:username')


### PR DESCRIPTION
This pull request includes several changes to update the user identification method in various controllers and their corresponding test files. The changes involve replacing the use of `sub` with `id` for user identification and updating the types accordingly.

### User Identification Update:

* [`src/auth/interfaces/UserRequest.ts`](diffhunk://#diff-1e5dae5cb89488314f2af4fb938a99831ae0f6e8720810ff1899e30c85cff3a5R1-R5): Added `RequestWithUser` interface to include `user` property of type `User`.

### Controller Updates:

* [`src/feed/controllers/feed.controller.ts`](diffhunk://#diff-30217de3f14c7c407aaf1c1f2b6b547cc9ff77840cd6493976196194bc0a3ef1L35-R40): Updated `getFeed` method to use `RequestWithUser` and replaced `sub` with `id` for user identification.
* [`src/interaction/controllers/comment.controller.ts`](diffhunk://#diff-06aace24d52fe620e6bbd03b20ff242bcdcd53e63113d629929027d0bcfc99dcL36-R41): Updated `create` method to use `RequestWithUser` and replaced `sub` with `id` for user identification.
* [`src/interaction/controllers/like.controller.ts`](diffhunk://#diff-38d62a879ecfdfcf1852d2b8c6294319139790dab86ca2df3cf63795c6d06619L37-R51): Updated `create` and `remove` methods to use `RequestWithUser` and replaced `sub` with `id` for user identification.
* [`src/notification/controllers/notification.controller.ts`](diffhunk://#diff-a4921c65e4d91596871339cd2eb58b8c8a947ab232b0dace59c95f6731df07afL28-R48): Updated methods to use `RequestWithUser` and replaced `sub` with `id` for user identification.

### Test File Updates:

* [`src/feed/controllers/feed.controller.spec.ts`](diffhunk://#diff-9dcf8a0e3afa710bc323ab82319cb97aea6d83155b793649ecfe58655e35cec1R43-R51): Updated mock requests and tests to use `RequestWithUser` and replaced `sub` with `id` for user identification. [[1]](diffhunk://#diff-9dcf8a0e3afa710bc323ab82319cb97aea6d83155b793649ecfe58655e35cec1R43-R51) [[2]](diffhunk://#diff-9dcf8a0e3afa710bc323ab82319cb97aea6d83155b793649ecfe58655e35cec1L66-R85) [[3]](diffhunk://#diff-9dcf8a0e3afa710bc323ab82319cb97aea6d83155b793649ecfe58655e35cec1L115-R128)
* [`src/interaction/controllers/comment.controller.spec.ts`](diffhunk://#diff-ee4b1c9b8e661d64c783751f20dc86a4044b3814c2ee93d0cf31b8500802b06aL27-R35): Updated mock requests and tests to use `RequestWithUser` and replaced `sub` with `id` for user identification. [[1]](diffhunk://#diff-ee4b1c9b8e661d64c783751f20dc86a4044b3814c2ee93d0cf31b8500802b06aL27-R35) [[2]](diffhunk://#diff-ee4b1c9b8e661d64c783751f20dc86a4044b3814c2ee93d0cf31b8500802b06aL194-R205) [[3]](diffhunk://#diff-ee4b1c9b8e661d64c783751f20dc86a4044b3814c2ee93d0cf31b8500802b06aL396-R414)
* [`src/interaction/controllers/like.controller.spec.ts`](diffhunk://#diff-109b49aa4ecd178368eeef1a6030bf68355ad77e4d1c361c2ae49a3f99572989L85-R94): Updated mock requests and tests to use `RequestWithUser` and replaced `sub` with `id` for user identification. [[1]](diffhunk://#diff-109b49aa4ecd178368eeef1a6030bf68355ad77e4d1c361c2ae49a3f99572989L85-R94) [[2]](diffhunk://#diff-109b49aa4ecd178368eeef1a6030bf68355ad77e4d1c361c2ae49a3f99572989L113-R128)
* [`src/notification/controllers/notification.controller.spec.ts`](diffhunk://#diff-c9db0ff1bbcc4463a051e92c13688841a028237f469ba3dbc5dd742d5a7819b9L113-R120): Updated mock requests and tests to use `RequestWithUser` and replaced `sub` with `id` for user identification. [[1]](diffhunk://#diff-c9db0ff1bbcc4463a051e92c13688841a028237f469ba3dbc5dd742d5a7819b9L113-R120) [[2]](diffhunk://#diff-c9db0ff1bbcc4463a051e92c13688841a028237f469ba3dbc5dd742d5a7819b9L138-R151) [[3]](diffhunk://#diff-c9db0ff1bbcc4463a051e92c13688841a028237f469ba3dbc5dd742d5a7819b9L159-R178)
* [`src/photo/controllers/photo.controller.spec.ts`](diffhunk://#diff-deced4459897af783717374aa08343c14a279bc5bdcecd625a806b5f4409053cL75-R82): Updated mock requests and tests to use `RequestWithUser` and replaced `sub` with `id` for user identification. [[1]](diffhunk://#diff-deced4459897af783717374aa08343c14a279bc5bdcecd625a806b5f4409053cL75-R82) [[2]](diffhunk://#diff-deced4459897af783717374aa08343c14a279bc5bdcecd625a806b5f4409053cL112-R122) [[3]](diffhunk://#diff-deced4459897af783717374aa08343c14a279bc5bdcecd625a806b5f4409053cL144-R160)

### Additional Changes:

* [`.github/workflows/develop-tests.yml`](diffhunk://#diff-988d8adfeac692e44a42d5b0679ba248776652ef841238d1bcd1cf69eeb9b3a6L39-R41): Added a step to run linting before running tests.
* [`src/domain/entities/photo.entity.ts`](diffhunk://#diff-87842cd8e3e85edde62bd51a057614432915cf0d74b5079e1f2b3372b47f45c4L33-R33): Set default value for `hashtags` to an empty array.