### PR TITLE
    Remove ACL setting from storage service test

### DIFF
--- a/src/photo/services/storage.service.spec.ts
+++ b/src/photo/services/storage.service.spec.ts
@@ -108,7 +108,6 @@ describe('StorageService', () => {
         Key: expect.any(String) as string,
         Body: mockFile.buffer,
         ContentType: mockFile.mimetype,
-        ACL: 'public-read',
       });
     });
 


### PR DESCRIPTION
This pull request includes a small change to the `src/photo/services/storage.service.spec.ts` file. The change removes the 'public-read' ACL setting from the expected parameters in the `StorageService` test case.

* [`src/photo/services/storage.service.spec.ts`](diffhunk://#diff-644d10e6672295c34e0cc4c5055975e800e3d4c10cb9b28b27315416a8966c0bL111): Removed the 'public-read' ACL setting from the expected parameters in the `StorageService` test case.    The test no longer includes the 'public-read' ACL setting when validating S3 upload parameters. This change reflects updates to the storage service configuration.